### PR TITLE
Relay bot multiple msgs fix

### DIFF
--- a/plugins/relay/maubot.yaml
+++ b/plugins/relay/maubot.yaml
@@ -1,6 +1,6 @@
 maubot: 0.4.2
 id: org.wordpress.relay
-version: 1.0.0
+version: 1.0.1
 license: AGPL-3.0-or-later
 config: true
 extra_files:

--- a/plugins/relay/relay.py
+++ b/plugins/relay/relay.py
@@ -112,8 +112,9 @@ class Relay(Plugin):
             reply_in_thread = True
 
         messages = content.get("messages", [])
-        for message in messages:
-            await evt.respond(content=message, markdown=True, in_thread=reply_in_thread)
+        if messages:
+            for message in messages:
+                await evt.respond(content=message, markdown=True, in_thread=reply_in_thread)
             return
 
         if "message" in content:


### PR DESCRIPTION
This PR fixes a misplaced "return" which caused only the first message to be posted in room out of multiple messages returned in json.